### PR TITLE
Bitfield work

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
-use crate::error::SensorError;
+use crate::{error::SensorError, register::{Register, Bank0}};
 
 pub(crate) trait Bitfield {
     const BITMASK: u8;
+    type Reg: Register;
+    const REGISTER: Self::Reg;
 
     /// Bit value of a discriminant, shifted to the correct position if
     /// necessary
@@ -47,6 +49,8 @@ impl AccelRange {
 
 impl Bitfield for AccelRange {
     const BITMASK: u8 = 0b0110_0000;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::ACCEL_CONFIG0;
 
     fn bits(self) -> u8 {
         // `ACCEL_UI_FS_SEL` occupies bits 6:5 in the register
@@ -106,6 +110,8 @@ impl GyroRange {
 
 impl Bitfield for GyroRange {
     const BITMASK: u8 = 0b0110_0000;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::GYRO_CONFIG1;
 
     fn bits(self) -> u8 {
         // `GYRO_UI_FS_SEL` occupies bits 6:5 in the register
@@ -154,6 +160,8 @@ pub enum PowerMode {
 
 impl Bitfield for PowerMode {
     const BITMASK: u8 = 0b0000_1111;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::PWR_MGMT0;
 
     fn bits(self) -> u8 {
         // `GYRO_MODE` occupies bits 3:2 in the register
@@ -235,6 +243,8 @@ impl AccelOdr {
 
 impl Bitfield for AccelOdr {
     const BITMASK: u8 = 0b0000_1111;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::ACCEL_CONFIG0;
 
     fn bits(self) -> u8 {
         // `ACCEL_ODR` occupies bits 3:0 in the register
@@ -284,6 +294,8 @@ pub enum AccLpAvg {
 
 impl Bitfield for AccLpAvg {
     const BITMASK: u8 = 0b1111_0000;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::ACCEL_CONFIG1;
 
     fn bits(self) -> u8 {
         (self as u8) << 4
@@ -306,6 +318,8 @@ pub enum AccelDlpfBw {
 
 impl Bitfield for AccelDlpfBw {
     const BITMASK: u8 = 0b0000_0111;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::ACCEL_CONFIG1;
 
     fn bits(self) -> u8 {
         self as u8
@@ -325,6 +339,8 @@ pub enum TempDlpfBw {
 }
 impl Bitfield for TempDlpfBw {
     const BITMASK: u8 = 0b0111_0000;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::TEMP_CONFIG0;
 
     fn bits(self) -> u8 {
         (self as u8) << 4
@@ -345,6 +361,8 @@ pub enum GyroLpFiltBw {
 }
 impl Bitfield for GyroLpFiltBw {
     const BITMASK: u8 = 0b0000_0111;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::GYRO_CONFIG1;
 
     fn bits(self) -> u8 {
         self as u8
@@ -390,6 +408,8 @@ impl GyroOdr {
 
 impl Bitfield for GyroOdr {
     const BITMASK: u8 = 0b0000_1111;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::GYRO_CONFIG0;
 
     fn bits(self) -> u8 {
         // `GYRO_ODR` occupies bits 3:0 in the register
@@ -422,3 +442,21 @@ impl TryFrom<u8> for GyroOdr {
         }
     }
 }
+
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum SoftReset {
+    Enabled = 0b0,
+    _Disabled = 0b1,
+}
+
+impl Bitfield for SoftReset {
+    const BITMASK: u8 = 0b0001_0000;
+    type Reg = Bank0;
+    const REGISTER: Self::Reg = Self::Reg::SIGNAL_PATH_RESET;
+
+    fn bits(self) -> u8 {
+        (self as u8) << 4
+    }
+}
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl GyroRange {
 impl Bitfield for GyroRange {
     const BITMASK: u8 = 0b0110_0000;
     type Reg = Bank0;
-    const REGISTER: Self::Reg = Self::Reg::GYRO_CONFIG1;
+    const REGISTER: Self::Reg = Self::Reg::GYRO_CONFIG0;
 
     fn bits(self) -> u8 {
         // `GYRO_UI_FS_SEL` occupies bits 6:5 in the register
@@ -284,16 +284,16 @@ impl TryFrom<u8> for AccelOdr {
 /// Acceleration Low Power Averaging
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AccLpAvg {
-    X2  = 0b0000,
-    X4  = 0b0001,
-    X8  = 0b0010,
-    X16 = 0b0011,
-    X32 = 0b0100,
-    X64 = 0b0101,
+    X2  = 0b000,
+    X4  = 0b001,
+    X8  = 0b010,
+    X16 = 0b011,
+    X32 = 0b100,
+    X64 = 0b101,
 }
 
 impl Bitfield for AccLpAvg {
-    const BITMASK: u8 = 0b1111_0000;
+    const BITMASK: u8 = 0b0111_0000;
     type Reg = Bank0;
     const REGISTER: Self::Reg = Self::Reg::ACCEL_CONFIG1;
 
@@ -306,14 +306,14 @@ impl Bitfield for AccLpAvg {
 /// Acceleration Digital Low Pass Filter options
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AccelDlpfBw {
-    Bypassed = 0b0000,
-    Hz180    = 0b0001,
-    Hz121    = 0b0010,
-    Hz73     = 0b0011,
-    Hz53     = 0b0100,
-    Hz34     = 0b0101,
-    Hz25     = 0b0110,
-    Hz16     = 0b0111,
+    Bypassed = 0b000,
+    Hz180    = 0b001,
+    Hz121    = 0b010,
+    Hz73     = 0b011,
+    Hz53     = 0b100,
+    Hz34     = 0b101,
+    Hz25     = 0b110,
+    Hz16     = 0b111,
 }
 
 impl Bitfield for AccelDlpfBw {
@@ -329,13 +329,13 @@ impl Bitfield for AccelDlpfBw {
 /// Temperature DLPF (Digital Low Pass Filter) Bandwidth
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TempDlpfBw {
-    Bypassed = 0b0000,
-    Hz180    = 0b0001,
-    Hz72     = 0b0010,
-    Hz34     = 0b0011,
-    Hz16     = 0b0100,
-    Hz8      = 0b0101,
-    Hz4      = 0b0110,
+    Bypassed = 0b000,
+    Hz180    = 0b001,
+    Hz72     = 0b010,
+    Hz34     = 0b011,
+    Hz16     = 0b100,
+    Hz8      = 0b101,
+    Hz4      = 0b110,
 }
 impl Bitfield for TempDlpfBw {
     const BITMASK: u8 = 0b0111_0000;
@@ -350,14 +350,14 @@ impl Bitfield for TempDlpfBw {
 /// Gyroscope UI low pass filter bandwidth
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GyroLpFiltBw {
-    Bypassed = 0b0000,
-    Hz180    = 0b0001,
-    Hz121    = 0b0010,
-    Hz73     = 0b0011,
-    Hz53     = 0b0100,
-    Hz34     = 0b0101,
-    Hz25     = 0b0110,
-    Hz16     = 0b0111,
+    Bypassed = 0b000,
+    Hz180    = 0b001,
+    Hz121    = 0b010,
+    Hz73     = 0b011,
+    Hz53     = 0b100,
+    Hz34     = 0b101,
+    Hz25     = 0b110,
+    Hz16     = 0b111,
 }
 impl Bitfield for GyroLpFiltBw {
     const BITMASK: u8 = 0b0000_0111;

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,85 @@ impl TryFrom<u8> for AccelOdr {
     }
 }
 
+/// Acceleration Low Power Averaging
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccLpAvg {
+    X2  = 0b0000,
+    X4  = 0b0001,
+    X8  = 0b0010,
+    X16 = 0b0011,
+    X32 = 0b0100,
+    X64 = 0b0101,
+}
+
+impl Bitfield for AccLpAvg {
+    const BITMASK: u8 = 0b1111_0000;
+
+    fn bits(self) -> u8 {
+        (self as u8) << 4
+    }
+}
+
+
+/// Acceleration Digital Low Pass Filter options
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AccelDlpfBw {
+    Bypassed = 0b0000,
+    Hz180    = 0b0001,
+    Hz121    = 0b0010,
+    Hz73     = 0b0011,
+    Hz53     = 0b0100,
+    Hz34     = 0b0101,
+    Hz25     = 0b0110,
+    Hz16     = 0b0111,
+}
+
+impl Bitfield for AccelDlpfBw {
+    const BITMASK: u8 = 0b0000_0111;
+
+    fn bits(self) -> u8 {
+        self as u8
+    }
+}
+
+/// Temperature DLPF (Digital Low Pass Filter) Bandwidth
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TempDlpfBw {
+    Bypassed = 0b0000,
+    Hz180    = 0b0001,
+    Hz72     = 0b0010,
+    Hz34     = 0b0011,
+    Hz16     = 0b0100,
+    Hz8      = 0b0101,
+    Hz4      = 0b0110,
+}
+impl Bitfield for TempDlpfBw {
+    const BITMASK: u8 = 0b0111_0000;
+
+    fn bits(self) -> u8 {
+        (self as u8) << 4
+    }
+}
+
+/// Gyroscope UI low pass filter bandwidth
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GyroLpFiltBw {
+    Bypassed = 0b0000,
+    Hz180    = 0b0001,
+    Hz121    = 0b0010,
+    Hz73     = 0b0011,
+    Hz53     = 0b0100,
+    Hz34     = 0b0101,
+    Hz25     = 0b0110,
+    Hz16     = 0b0111,
+}
+impl Bitfield for GyroLpFiltBw {
+    const BITMASK: u8 = 0b0000_0111;
+
+    fn bits(self) -> u8 {
+        self as u8
+    }
+}
 /// Gyroscope ODR selection values
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GyroOdr {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-use crate::{error::SensorError, register::{Register, Bank0}};
+use crate::{
+    error::SensorError,
+    register::{Bank0, Register},
+};
 
 pub(crate) trait Bitfield {
     const BITMASK: u8;
@@ -302,7 +305,6 @@ impl Bitfield for AccLpAvg {
     }
 }
 
-
 /// Acceleration Digital Low Pass Filter options
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AccelDlpfBw {
@@ -443,10 +445,9 @@ impl TryFrom<u8> for GyroOdr {
     }
 }
 
-
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum SoftReset {
-    Enabled = 0b0,
+    Enabled   = 0b0,
     _Disabled = 0b1,
 }
 
@@ -459,4 +460,3 @@ impl Bitfield for SoftReset {
         (self as u8) << 4
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use accelerometer::{
     Accelerometer,
     RawAccelerometer,
 };
-use config::{GyroLpFiltBw, TempDlpfBw, AccLpAvg, AccelDlpfBw, SoftReset};
+use config::{AccLpAvg, AccelDlpfBw, GyroLpFiltBw, SoftReset, TempDlpfBw};
 use embedded_hal::blocking::{
     delay::DelayUs,
     i2c::{Write, WriteRead},
@@ -149,12 +149,14 @@ where
         self.read_reg_i16(&Bank0::TEMP_DATA1, &Bank0::TEMP_DATA0)
     }
 
-    /// Sets the bandwidth of the temperature signal DLPF (Digital Low Pass Filter)
-    /// This field can be changed on the fly even if the sensor is on
+    /// Sets the bandwidth of the temperature signal DLPF (Digital Low Pass
+    /// Filter)
+    ///
+    /// This field can be changed on the fly even if the sensor is
+    /// on
     pub fn set_temp_dlpf(&mut self, freq: TempDlpfBw) -> Result<(), Error<E>> {
         self.update_reg(freq)
     }
-
 
     /// Return the currently configured power mode
     pub fn power_mode(&mut self) -> Result<PowerMode, Error<E>> {
@@ -186,11 +188,12 @@ where
     }
 
     /// Set acceleration low-power averaging value.
-    /// This field cannot be changed when the accel sensor is in LPM (LowPowerMode)
-    pub fn set_accel_low_power_avg(&mut self, avg_val: AccLpAvg)-> Result<(), Error<E>> {
+    ///
+    /// This field cannot be changed when the accel sensor is in LPM
+    /// (LowPowerMode)
+    pub fn set_accel_low_power_avg(&mut self, avg_val: AccLpAvg) -> Result<(), Error<E>> {
         self.update_reg(avg_val)
     }
-
 
     /// Return the currently configured gyroscope range
     pub fn gyro_range(&mut self) -> Result<GyroRange, Error<E>> {
@@ -320,11 +323,7 @@ where
     }
 
     /// Read two registers and combine them into a single value.
-    fn read_reg_i16<R: Register>(
-        &mut self,
-        reg_hi: &R,
-        reg_lo: &R,
-    ) -> Result<i16, Error<E>> {
+    fn read_reg_i16<R: Register>(&mut self, reg_hi: &R, reg_lo: &R) -> Result<i16, Error<E>> {
         let data_hi = self.read_reg(reg_hi)?;
         let data_lo = self.read_reg(reg_lo)?;
 
@@ -349,7 +348,6 @@ where
     /// Rather than overwriting any active bits in the register, we first read
     /// in its current value and then update it accordingly using the given
     /// value and mask before writing back the desired value.
-    // fn update_reg(&mut self, reg: &dyn Register, value: u8, mask: u8) -> Result<(), Error<E>> {
     fn update_reg<BF: Bitfield>(&mut self, value: BF) -> Result<(), Error<E>> {
         if BF::REGISTER.read_only() {
             Err(Error::SensorError(SensorError::WriteToReadOnly))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use accelerometer::{
     Accelerometer,
     RawAccelerometer,
 };
+use config::{GyroLpFiltBw, TempDlpfBw, AccLpAvg, AccelDlpfBw};
 use embedded_hal::blocking::{
     delay::DelayUs,
     i2c::{Write, WriteRead},
@@ -148,6 +149,13 @@ where
         self.read_reg_i16(&Bank0::TEMP_DATA1, &Bank0::TEMP_DATA0)
     }
 
+    /// Sets the bandwidth of the temperature signal DLPF (Digital Low Pass Filter)
+    /// This field can be changed on the fly even if the sensor is on
+    pub fn set_temp_dlpf(&mut self, freq: TempDlpfBw) -> Result<(), Error<E>> {
+        self.update_reg(&Bank0::TEMP_CONFIG0, freq.bits(), TempDlpfBw::BITMASK)
+    }
+
+
     /// Return the currently configured power mode
     pub fn power_mode(&mut self) -> Result<PowerMode, Error<E>> {
         //  `GYRO_MODE` occupies bits 3:2 in the register
@@ -177,6 +185,13 @@ where
         self.update_reg(&Bank0::ACCEL_CONFIG0, range.bits(), AccelRange::BITMASK)
     }
 
+    /// Set acceleration low-power averaging value.
+    /// This field cannot be changed when the accel sensor is in LPM (LowPowerMode)
+    pub fn set_accel_low_power_avg(&mut self, avg_val: AccLpAvg)-> Result<(), Error<E>> {
+        self.update_reg(&Bank0::APEX_CONFIG1, avg_val.bits(), AccLpAvg::BITMASK)
+    }
+
+
     /// Return the currently configured gyroscope range
     pub fn gyro_range(&mut self) -> Result<GyroRange, Error<E>> {
         // `GYRO_UI_FS_SEL` occupies bits 6:5 in the register
@@ -191,6 +206,12 @@ where
         self.update_reg(&Bank0::GYRO_CONFIG0, range.bits(), GyroRange::BITMASK)
     }
 
+    /// Selects GYRO UI low pass filter bandwidth
+    /// This field can be changed on the fly even if gyro sonsor is on
+    pub fn set_gyro_lp_filter_bandwidth(&mut self, freq: GyroLpFiltBw) -> Result<(), Error<E>> {
+        self.update_reg(&Bank0::GYRO_CONFIG1, freq.bits(), GyroLpFiltBw::BITMASK)
+    }
+
     /// Return the currently configured output data rate for the accelerometer
     pub fn accel_odr(&mut self) -> Result<AccelOdr, Error<E>> {
         // `ACCEL_ODR` occupies bits 3:0 in the register
@@ -203,6 +224,12 @@ where
     /// Set the output data rate of the accelerometer
     pub fn set_accel_odr(&mut self, odr: AccelOdr) -> Result<(), Error<E>> {
         self.update_reg(&Bank0::ACCEL_CONFIG0, odr.bits(), AccelOdr::BITMASK)
+    }
+
+    /// Selects ACCEL UI low pass filter bandwidth
+    /// This field can be changed on-the-fly even if accel sonsor is on
+    pub fn set_accel_dlpf_bw(&mut self, odr: AccelDlpfBw) -> Result<(), Error<E>> {
+        self.update_reg(&Bank0::ACCEL_CONFIG1, odr.bits(), AccelDlpfBw::BITMASK)
     }
 
     /// Return the currently configured output data rate for the gyroscope


### PR DESCRIPTION
This adds a couple of bit-fields to read/write, as well as streamlining the use of read/write methods by means of coupling a bit-field to its register address and offset using associated consts/types.


- [x] verify all changes are in line with specs

#### Bitfields added, and chapter in datasheet: https://invensense.tdk.com/wp-content/uploads/2021/07/ds-000451_icm-42670-p-datasheet.pdf

- Acceleration low power averaging: 16.31
- Acceleration digital low-pass filter: 16.31
- Temperature digital low-pass filter: 16.29
- Gyro digital low-pass filter: 16.30
- software reset: 16.3

#### Register read/write structure

instead of having to manually choose which `&dyn Register` to provide when calling a bit-field read/write, the `Bitfield` trait must now define which `Register` it's associated with, and which `Register` implementing value it's associated with. The read/write methods take these definitions required by `Bitfield` implementation to determine the metadata needed to read/write the correct register.